### PR TITLE
Исправление разметки schema.org

### DIFF
--- a/assets/snippets/DocLister/config/core/crumbs.json
+++ b/assets/snippets/DocLister/config/core/crumbs.json
@@ -1,7 +1,7 @@
 {
   "debug": "0",
   "tpl": "@CODE:<li itemprop=\"itemListElement\" itemscope itemtype=\"http://schema.org/ListItem\"><meta itemprop=\"position\" content=\"[+iteration+]\" /><a href=\"[+url+]\" title=\"[+e.title+]\"  itemprop=\"item\"><span itemprop=\"name\">[+title+]</span></a></li>",
-  "tplCurrent": "@CODE:<li class=\"active\" itemprop=\"itemListElement\" itemscope itemtype=\"http://schema.org/ListItem\"><meta itemprop=\"position\" content=\"[+iteration+]\" /><span itemprop=\"item\">[+title+]</span></li>",
+  "tplCurrent": "@CODE:<li class=\"active\" itemprop=\"itemListElement\" itemscope itemtype=\"http://schema.org/ListItem\"><meta itemprop=\"position\" content=\"[+iteration+]\" /><span itemprop=\"name\">[+title+]</span></li>",
   "ownerTPL": "@CODE:<nav class=\"breadcrumbs\"><ul class=\"breadcrumb\" itemscope itemtype=\"http://schema.org/BreadcrumbList\">[+crumbs.wrap+]</ul></nav>",
   "sysKey": "crumbs",
   "urlScheme": "full"


### PR DESCRIPTION
Гугл прислал сообщение, что у активной крошки неправильная разметка.
Исправьте разметку типа "Строки навигации" на сайте Укажите "name" или "item.name"